### PR TITLE
Feature/connect to api

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,0 +1,4 @@
+export const getAllStories = () => {
+  return fetch('https://api.nytimes.com/svc/topstories/v2/climate.json?api-key=b3M1MC9DPZ6AYoCBVQ98cGQZYXRjwuoZ')
+    .then(response => response.json())
+} 

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -31,45 +31,20 @@ class App extends Component {
   componentDidMount() {
     fetch('https://api.nytimes.com/svc/topstories/v2/climate.json?api-key=b3M1MC9DPZ6AYoCBVQ98cGQZYXRjwuoZ')
       .then(response => response.json())
-      .then(stories => {
-        console.log(stories.results)
-        this.setState({ stories: cleanStoriesData(stories) })
-      })
+      .then(stories => this.setState({ stories: cleanStoriesData(stories), storiesError: '' }))
+      .catch(err => this.setState({ storiesError: 'Oops, something went wrong' }))
   }
-
-
 
   render() {
     return (
       <div className="App">
         <Header />
-        {!this.state.stories.length && <h2>Loading...</h2>}
+        {this.state.storiesError && <h2>{this.state.storiesError}</h2>}
+        {!this.state.stories.length && !this.state.storiesError && <h2>Loading...</h2>}
         <NewsView stories={this.state.stories} />
       </div>
     );
   }
 }
 
-
 export default App;
-
-
-// {
-//   "section": "climate",
-//   "title": "Amid Biden Climate Push, a Question Looms: Is America’s Word Good?",
-//   "abstract": "After four years of “America First,” the president tries this week to reclaim U.S. leadership in the fight against climate change. Can the world trust his promises?",
-//   "url": "https://www.nytimes.com/2021/04/19/climate/biden-climate-change.html",
-//   "byline": "By Lisa Friedman",
-//   "published_date": "2021-04-19T18:02:19-04:00",
-//   "multimedia": [
-//       {
-//           "url": "https://static01.nyt.com/images/2021/04/19/climate/19CLI-BIDENCLIMATE1/19CLI-BIDENCLIMATE1-superJumbo.jpg",
-//           "format": "superJumbo",
-//           "height": 1365,
-//           "width": 2048,
-//           "type": "image",
-//           "subtype": "photo",
-//           "caption": "President Biden will convene a virtual summit this week to show that the U.S. is ready to reassert itself on the world stage on matters of climate change and others.",
-//           "copyright": "Doug Mills/The New York Times"
-//       }]
-//     }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -13,10 +13,8 @@ const cleanStoriesData = (stories) => {
       publishedDate: story.published_date,
       overview: story.abstract,
       link: story.url,
-      bigPhoto: story.multimedia[0].url,
-      bigPhotoAlt: story.multimedia[0].caption,
-      smallPhoto: story.multimedia[1].url,
-      smallPhotoAlt: story.multimedia[0].caption
+      photo: story.multimedia[0].url,
+      photoAlt: story.multimedia[0].caption,
     }
   })
 }
@@ -46,7 +44,7 @@ class App extends Component {
       <div className="App">
         <Header />
         {!this.state.stories.length && <h2>Loading...</h2>}
-        {/* <NewsView stories={this.state.stories} /> */}
+        <NewsView stories={this.state.stories} />
       </div>
     );
   }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -7,44 +7,7 @@ class App extends Component {
   constructor() {
     super()
     this.state = {
-      stories: [{
-        "section": "climate",
-        "title": "Amid Biden Climate Push, a Question Looms: Is America’s Word Good?",
-        "abstract": "After four years of “America First,” the president tries this week to reclaim U.S. leadership in the fight against climate change. Can the world trust his promises?",
-        "url": "https://www.nytimes.com/2021/04/19/climate/biden-climate-change.html",
-        "byline": "By Lisa Friedman",
-        "published_date": "2021-04-19T18:02:19-04:00",
-        "multimedia": [
-          {
-            "url": "https://static01.nyt.com/images/2021/04/19/climate/19CLI-BIDENCLIMATE1/19CLI-BIDENCLIMATE1-superJumbo.jpg",
-            "format": "superJumbo",
-            "height": 1365,
-            "width": 2048,
-            "type": "image",
-            "subtype": "photo",
-            "caption": "President Biden will convene a virtual summit this week to show that the U.S. is ready to reassert itself on the world stage on matters of climate change and others.",
-            "copyright": "Doug Mills/The New York Times"
-          }]
-      },
-      {
-        "section": "climate",
-        "title": "Amid Biden Climate Push, a Question Looms: Is America’s Word Good?",
-        "abstract": "After four years of “America First,” the president tries this week to reclaim U.S. leadership in the fight against climate change. Can the world trust his promises?",
-        "url": "https://www.nytimes.com/2021/04/19/climate/biden-climate-change.html",
-        "byline": "By Lisa Friedman",
-        "published_date": "2021-04-19T18:02:19-04:00",
-        "multimedia": [
-          {
-            "url": "https://static01.nyt.com/images/2021/04/19/climate/19CLI-BIDENCLIMATE1/19CLI-BIDENCLIMATE1-superJumbo.jpg",
-            "format": "superJumbo",
-            "height": 1365,
-            "width": 2048,
-            "type": "image",
-            "subtype": "photo",
-            "caption": "President Biden will convene a virtual summit this week to show that the U.S. is ready to reassert itself on the world stage on matters of climate change and others.",
-            "copyright": "Doug Mills/The New York Times"
-          }]
-      }]
+      stories: []
     }
   }
 
@@ -58,6 +21,7 @@ class App extends Component {
     return (
       <div className="App">
         <Header />
+        {!this.state.stories.length && <h2>Loading...</h2>}
         <NewsView stories={this.state.stories} />
       </div>
     );

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -3,11 +3,14 @@ import React, { Component } from 'react';
 import NewsView from '../NewsView/NewsView';
 import Header from '../Header/Header';
 
-
+const generateId = (index) => {
+  return index + new Date().getTime();
+}
 
 const cleanStoriesData = (stories) => {
-  return stories.results.map(story => {
+  return stories.results.map((story, i) => {
     return {
+      id: generateId(i),
       title: story.title,
       author: story.byline,
       publishedDate: story.published_date,

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -3,26 +3,50 @@ import React, { Component } from 'react';
 import NewsView from '../NewsView/NewsView';
 import Header from '../Header/Header';
 
+
+
+const cleanStoriesData = (stories) => {
+  return stories.results.map(story => {
+    return {
+      title: story.title,
+      author: story.byline,
+      publishedDate: story.published_date,
+      overview: story.abstract,
+      link: story.url,
+      bigPhoto: story.multimedia[0].url,
+      bigPhotoAlt: story.multimedia[0].caption,
+      smallPhoto: story.multimedia[1].url,
+      smallPhotoAlt: story.multimedia[0].caption
+    }
+  })
+}
+
 class App extends Component {
   constructor() {
     super()
     this.state = {
-      stories: []
+      stories: [],
+      storiesError: ''
     }
   }
 
   componentDidMount() {
     fetch('https://api.nytimes.com/svc/topstories/v2/climate.json?api-key=b3M1MC9DPZ6AYoCBVQ98cGQZYXRjwuoZ')
       .then(response => response.json())
-      .then(stories => this.setState({ stories: stories.results }))
+      .then(stories => {
+        console.log(stories.results)
+        this.setState({ stories: cleanStoriesData(stories) })
+      })
   }
+
+
 
   render() {
     return (
       <div className="App">
         <Header />
         {!this.state.stories.length && <h2>Loading...</h2>}
-        <NewsView stories={this.state.stories} />
+        {/* <NewsView stories={this.state.stories} /> */}
       </div>
     );
   }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,27 +1,28 @@
 import './App.css';
 import { getAllStories } from '../../apiCalls';
+import { cleanStoriesData } from '../../utilities';
 import React, { Component } from 'react';
 import NewsView from '../NewsView/NewsView';
 import Header from '../Header/Header';
 
-const generateId = (index) => {
-  return index + new Date().getTime();
-}
+// const generateId = (index) => {
+//   return index + new Date().getTime();
+// }
 
-const cleanStoriesData = (stories) => {
-  return stories.results.map((story, i) => {
-    return {
-      id: generateId(i),
-      title: story.title,
-      author: story.byline,
-      publishedDate: story.published_date,
-      overview: story.abstract,
-      link: story.url,
-      photo: story.multimedia[0].url,
-      photoAlt: story.multimedia[0].caption,
-    }
-  })
-}
+// const cleanStoriesData = (stories) => {
+//   return stories.results.map((story, i) => {
+//     return {
+//       id: generateId(i),
+//       title: story.title,
+//       author: story.byline,
+//       publishedDate: story.published_date,
+//       overview: story.abstract,
+//       link: story.url,
+//       photo: story.multimedia[0].url,
+//       photoAlt: story.multimedia[0].caption,
+//     }
+//   })
+// }
 
 class App extends Component {
   constructor() {
@@ -33,8 +34,6 @@ class App extends Component {
   }
 
   componentDidMount() {
-    // fetch('https://api.nytimes.com/svc/topstories/v2/climate.json?api-key=b3M1MC9DPZ6AYoCBVQ98cGQZYXRjwuoZ')
-    //   .then(response => response.json())
     getAllStories()
       .then(stories => this.setState({ stories: cleanStoriesData(stories), storiesError: '' }))
       .catch(err => this.setState({ storiesError: 'Oops, something went wrong' }))

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -5,25 +5,6 @@ import React, { Component } from 'react';
 import NewsView from '../NewsView/NewsView';
 import Header from '../Header/Header';
 
-// const generateId = (index) => {
-//   return index + new Date().getTime();
-// }
-
-// const cleanStoriesData = (stories) => {
-//   return stories.results.map((story, i) => {
-//     return {
-//       id: generateId(i),
-//       title: story.title,
-//       author: story.byline,
-//       publishedDate: story.published_date,
-//       overview: story.abstract,
-//       link: story.url,
-//       photo: story.multimedia[0].url,
-//       photoAlt: story.multimedia[0].caption,
-//     }
-//   })
-// }
-
 class App extends Component {
   constructor() {
     super()

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,4 +1,5 @@
 import './App.css';
+import { getAllStories } from '../../apiCalls';
 import React, { Component } from 'react';
 import NewsView from '../NewsView/NewsView';
 import Header from '../Header/Header';
@@ -32,8 +33,9 @@ class App extends Component {
   }
 
   componentDidMount() {
-    fetch('https://api.nytimes.com/svc/topstories/v2/climate.json?api-key=b3M1MC9DPZ6AYoCBVQ98cGQZYXRjwuoZ')
-      .then(response => response.json())
+    // fetch('https://api.nytimes.com/svc/topstories/v2/climate.json?api-key=b3M1MC9DPZ6AYoCBVQ98cGQZYXRjwuoZ')
+    //   .then(response => response.json())
+    getAllStories()
       .then(stories => this.setState({ stories: cleanStoriesData(stories), storiesError: '' }))
       .catch(err => this.setState({ storiesError: 'Oops, something went wrong' }))
   }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -48,6 +48,12 @@ class App extends Component {
     }
   }
 
+  componentDidMount() {
+    fetch('https://api.nytimes.com/svc/topstories/v2/climate.json?api-key=b3M1MC9DPZ6AYoCBVQ98cGQZYXRjwuoZ')
+      .then(response => response.json())
+      .then(stories => this.setState({ stories: stories.results }))
+  }
+
   render() {
     return (
       <div className="App">

--- a/src/components/NewsView/NewsView.js
+++ b/src/components/NewsView/NewsView.js
@@ -9,10 +9,9 @@ const NewsView = ({ stories }) => {
       <Story
         key={i}
         title={story.title}
-        // summary={story.abstract}
-        author={story.byline}
-        image={story.multimedia[0].url}
-        altText={story.multimedia[0].caption}
+        author={story.author}
+        image={story.photo}
+        altText={story.photoAlt}
       />
     )
   })
@@ -25,23 +24,3 @@ const NewsView = ({ stories }) => {
 }
 
 export default NewsView;
-
-// {
-//   "section": "climate",
-//   "title": "Amid Biden Climate Push, a Question Looms: Is America’s Word Good?",
-//   "abstract": "After four years of “America First,” the president tries this week to reclaim U.S. leadership in the fight against climate change. Can the world trust his promises?",
-//   "url": "https://www.nytimes.com/2021/04/19/climate/biden-climate-change.html",
-//   "byline": "By Lisa Friedman",
-//   "published_date": "2021-04-19T18:02:19-04:00",
-//   "multimedia": [
-//       {
-//           "url": "https://static01.nyt.com/images/2021/04/19/climate/19CLI-BIDENCLIMATE1/19CLI-BIDENCLIMATE1-superJumbo.jpg",
-//           "format": "superJumbo",
-//           "height": 1365,
-//           "width": 2048,
-//           "type": "image",
-//           "subtype": "photo",
-//           "caption": "President Biden will convene a virtual summit this week to show that the U.S. is ready to reassert itself on the world stage on matters of climate change and others.",
-//           "copyright": "Doug Mills/The New York Times"
-//       }]
-//     }

--- a/src/components/NewsView/NewsView.js
+++ b/src/components/NewsView/NewsView.js
@@ -4,10 +4,10 @@ import Story from '../Story/Story';
 
 const NewsView = ({ stories }) => {
 
-  const storyCards = stories.map((story, i) => {
+  const storyCards = stories.map((story) => {
     return (
       <Story
-        key={i}
+        key={story.id}
         title={story.title}
         author={story.author}
         image={story.photo}

--- a/src/components/Story/Story.css
+++ b/src/components/Story/Story.css
@@ -19,6 +19,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-around;
+  width: 70%;
 }
 
 .story-title:hover {

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,0 +1,18 @@
+export const generateId = (index) => {
+  return index + new Date().getTime();
+}
+
+export const cleanStoriesData = (stories) => {
+  return stories.results.map((story, i) => {
+    return {
+      id: generateId(i),
+      title: story.title,
+      author: story.byline,
+      publishedDate: story.published_date,
+      overview: story.abstract,
+      link: story.url,
+      photo: story.multimedia[0].url,
+      photoAlt: story.multimedia[0].caption,
+    }
+  })
+}


### PR DESCRIPTION
# PR CurrentClimate

### What does this do?

- [ ] Fix
- [X] Feature
- [X] Refactor
- [ ] Style
- [ ] Testing

### Are there any known bugs?

- [X] No
- [ ] Yes (if so please disclose in Notes for Reviewer & Next Iterations)

### Summary of the changes
Remove test API data from state. Create a separate API call file to hold GET request from NYT API. Connect request with componentDidMount() function in API to retrieve all API data on page load.
Create a cleaning function to filter API data to just store the data the app needs, and create a function to assign each data object with a unique id.

### What ticket(s) do the changes resolve?
#14 
#11 
#13 
Please Link Issues to this PR as necessary.

### Notes for the Reviewer
N/a

### How to Test Changes?
Make sure app still loads with API data showing all climate articles. No console errors.

### Next Iterations
- Work on single article view.
- Maybe use a library or package to create more robust unquie ids

